### PR TITLE
Set `baseURL` to custom domain

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = 'https://dddinjection.github.io/'
+baseURL = 'https://dddi.dev/'
 languageCode = 'ru-ru'
 title = 'Domain-Driven Design Injection'
 


### PR DESCRIPTION
This PR brings a new `baseURL` value that is equal to a custom domain. 
This should fix the console notification that “Access to the internal resource has been blocked by CORS policy”.